### PR TITLE
chore: product quick view modal added (#81)

### DIFF
--- a/src/components/ProductModal.css
+++ b/src/components/ProductModal.css
@@ -29,11 +29,11 @@
   border-radius: 16px;
   max-width: 900px;
   width: 100%;
-  max-height: 90vh;
-  overflow-y: auto;
+  height: 80vh;
   position: relative;
   animation: slideUp 0.3s ease;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
+  display: block;
 }
 
 .product-modal__close {
@@ -65,19 +65,22 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0;
+  height: 100%;
 }
 
 .product-modal__image {
   position: relative;
   overflow: hidden;
   border-radius: 16px 0 0 16px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .product-modal__image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  min-height: 400px;
 }
 
 .product-modal__badge {
@@ -99,6 +102,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  overflow-y: auto; /* keep content scrollable without resizing modal */
 }
 
 .product-modal__category {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -208,9 +208,23 @@ const Home = () => {
       <section className="section__container arrival__container" id="catalogue">
         <h2 className="section__header">NEW ARRIVALS</h2>
         <div className="arrival__grid">
-          <div className="arrival__card" onClick={() => openProductModal('hoodies-sweatshirts')} style={{cursor: 'pointer'}}>
-            <div className="arrival__image">
-              <img src="/assets/hoodie.jpg" alt="arrival" />
+          <div className="arrival__card">
+            <div className="arrival__image" style={{position: 'relative'}}>
+              <img 
+                src="/assets/hoodie.jpg" 
+                alt="arrival" 
+                onClick={() => navigate('/product/hoodies-sweatshirts')}
+                style={{cursor: 'pointer'}}
+              />
+              <button 
+                className="quick-view-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openProductModal('hoodies-sweatshirts');
+                }}
+              >
+                Quick View
+              </button>
             </div>
             <div className="arrival__content">
               <div>
@@ -220,9 +234,23 @@ const Home = () => {
               <span><i className="ri-arrow-right-line"></i></span>
             </div>
           </div>
-          <div className="arrival__card" onClick={() => openProductModal('coats-parkas')} style={{cursor: 'pointer'}}>
-            <div className="arrival__image">
-              <img src="/assets/arrival-2.jpg" alt="arrival" />
+          <div className="arrival__card">
+            <div className="arrival__image" style={{position: 'relative'}}>
+              <img 
+                src="/assets/arrival-2.jpg" 
+                alt="arrival" 
+                onClick={() => navigate('/product/coats-parkas')}
+                style={{cursor: 'pointer'}}
+              />
+              <button 
+                className="quick-view-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openProductModal('coats-parkas');
+                }}
+              >
+                Quick View
+              </button>
             </div>
             <div className="arrival__content">
               <div>
@@ -232,9 +260,23 @@ const Home = () => {
               <span><i className="ri-arrow-right-line"></i></span>
             </div>
           </div>
-          <div className="arrival__card" onClick={() => openProductModal('oversized-tshirt')} style={{cursor: 'pointer'}}>
-            <div className="arrival__image">
-              <img src="/assets/OVRSIZED.webp" alt="arrival" />
+          <div className="arrival__card">
+            <div className="arrival__image" style={{position: 'relative'}}>
+              <img 
+                src="/assets/OVRSIZED.webp" 
+                alt="arrival" 
+                onClick={() => navigate('/product/oversized-tshirt')}
+                style={{cursor: 'pointer'}}
+              />
+              <button 
+                className="quick-view-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openProductModal('oversized-tshirt');
+                }}
+              >
+                Quick View
+              </button>
             </div>
             <div className="arrival__content">
               <div>
@@ -269,9 +311,23 @@ const Home = () => {
       <section className="section__container favourite__container" id="favourite">
         <h2 className="section__header">YOUNG'S FAVOURITE</h2>
         <div className="favourite__grid">
-          <div className="favourite__card" onClick={() => openProductModal('instagram-trending')} style={{cursor: 'pointer'}}>
-            <div className="favourite__image">
-              <img src="/assets/Selena Gomez.webp" alt="favourite" />
+          <div className="favourite__card">
+            <div className="favourite__image" style={{position: 'relative'}}>
+              <img 
+                src="/assets/Selena Gomez.webp" 
+                alt="favourite" 
+                onClick={() => navigate('/product/instagram-trending')}
+                style={{cursor: 'pointer'}}
+              />
+              <button 
+                className="quick-view-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openProductModal('instagram-trending');
+                }}
+              >
+                Quick View
+              </button>
             </div>
             <div className="favourite__content">
               <div>
@@ -281,9 +337,23 @@ const Home = () => {
               <span><i className="ri-arrow-right-line"></i></span>
             </div>
           </div>
-          <div className="favourite__card" onClick={() => openProductModal('under-40')} style={{cursor: 'pointer'}}>
-            <div className="favourite__image">
-              <img src="/assets/favourite-2.jpg" alt="favourite" />
+          <div className="favourite__card">
+            <div className="favourite__image" style={{position: 'relative'}}>
+              <img 
+                src="/assets/favourite-2.jpg" 
+                alt="favourite" 
+                onClick={() => navigate('/product/under-40')}
+                style={{cursor: 'pointer'}}
+              />
+              <button 
+                className="quick-view-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openProductModal('under-40');
+                }}
+              >
+                Quick View
+              </button>
             </div>
             <div className="favourite__content">
               <div>
@@ -377,28 +447,7 @@ const Home = () => {
         onClose={closeProductModal}
       />
 
-      <style>{`
-        .nav__auth-item {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-        .nav__profile-link {
-          font-size: 2rem;
-          color: #e5d241; /* Your brand gold */
-          display: flex;
-          align-items: center;
-          transition: 0.3s;
-        }
-        .nav__profile-link:hover {
-          color: #fff;
-          transform: scale(1.1);
-        }
-        /* Mobile fix */
-        @media (max-width: 768px) {
-          .nav__profile-link { font-size: 2.5rem; margin-top: 10px; }
-        }
-`     }</style>
+      {/* moved styles into src/styles/index.css */}
     </>
   )
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -521,6 +521,73 @@ header {
   gap: 1rem;
 }
 
+.nav__auth-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.nav__profile-link {
+  font-size: 2rem;
+  color: #e5d241;
+  display: flex;
+  align-items: center;
+  transition: 0.3s;
+}
+.nav__profile-link:hover {
+  color: #fff;
+  transform: scale(1.1);
+}
+
+.quick-view-btn {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.02));
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: all 0.25s cubic-bezier(.2,.8,.2,1);
+  backdrop-filter: blur(8px) saturate(120%);
+  -webkit-backdrop-filter: blur(8px) saturate(120%);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.22);
+  z-index: 10;
+  background-clip: padding-box;
+}
+
+.arrival__card:hover .quick-view-btn,
+.favourite__card:hover .quick-view-btn {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.quick-view-btn:hover {
+  background: #e5d241;
+  color: #fff;
+  border-color: rgba(0,0,0,0.12);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 768px) {
+  .nav__profile-link {
+    font-size: 2.5rem;
+    margin-top: 10px;
+  }
+
+  .quick-view-btn {
+    opacity: 1;
+    font-size: 0.8rem;
+    padding: 0.5rem 1rem;
+    bottom: 0.75rem;
+    right: 0.75rem;
+  }
+}
+
 .arrival__content h4 {
   font-size: 1.5rem;
   font-weight: 500;


### PR DESCRIPTION
<!-- Title: keep short and start with a type, e.g. [ENHANCEMENT], [FIX], [CHORE] -->
# [ENHANCEMENT] product quick view modal added (#81)

## Description
Adds a Quick View overlay to product cards so users can preview items in a modal without leaving the page.
## Related Issue

- Closes: #81 

## Changes
- Changed the existing `ProductModal.jsx` to a reusable component with proper multiple images support

## Screenshots / Recordings
Quick View button gets revealed when hovered over the product
<img width="232" height="123" alt="Screenshot 2026-02-17 194612" src="https://github.com/user-attachments/assets/710a51ec-5c88-4111-ae5e-ef667b134f11" />

When hovered over the button to open the modal
<img width="235" height="113" alt="Screenshot 2026-02-17 194626" src="https://github.com/user-attachments/assets/c92fd915-e590-44ca-9ac9-5700da17bdc0" />

The Quick View modal
<img width="1245" height="798" alt="Screenshot 2026-02-17 143546" src="https://github.com/user-attachments/assets/6d6091e5-82de-46f8-8ab5-aebe59b09083" />


## Checklist
- [x] Code builds and runs locally